### PR TITLE
Make build scripts optional if not present

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,3 +1,4 @@
 #!/bin/sh
 # Usage: bin/compile <build-dir> <cache-dir> <env-dir>
+
 exec "$1"/bin/compile "$@"

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,10 @@
 #!/bin/sh
 # Usage: bin/detect <build-dir>
-exec "$1"/bin/detect "$@"
+
+if [ -f "$1"/bin/detect ]; then
+  exec "$1"/bin/detect "$@"
+elif [ -f "$1"/bin/compile ]; then
+  echo "Inline"
+else
+  exit 1
+fi

--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,6 @@
 #!/bin/sh
 # Usage: bin/release <build-dir>
-exec "$1"/bin/release "$@"
+
+if [ -f "$1"/bin/release ]; then
+  exec "$1"/bin/release "$@"
+fi


### PR DESCRIPTION
All three files were required, even if empty. This PR gives emphasis on project-specific bin/compile script, which is main reason why someone would use this buildpack. So bin/detect and bin/release scripts needn't exist.
