### PR TITLE
Switch instructions to use buildpack-registry URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,10 +25,10 @@ Phil Hagelberg originated this lovely idea.
     $ cat Procfile
     work: bin/run
 
-    $ heroku create -s cedar
+    $ heroku create
     ...
 
-    $ heroku config:add BUILDPACK_URL=http://github.com/kr/heroku-buildpack-inline.git
+    $ heroku buildpacks:add -i 1 heroku-community/inline
     ...
 
     $ git push heroku master


### PR DESCRIPTION
And remove obsolete stack/buildpacks CLI usage.

```
$ h buildpacks:versions heroku-community/inline
Version  Released At               Status
───────  ────────────────────────  ─────────
1        2018-06-13T13:38:31.996Z  published
```